### PR TITLE
Public continuous integration using Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ drunnerc
 drunner-install
 build_number.h
 version.number
+permissions
 
 # Visual Studio
 *.suo

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: cpp
+sudo: required
+dist: trusty
+before_install:
+   - sudo apt-get -qq update
+   - sudo apt-get install -y build-essential g++-multilib libboost-all-dev libyaml-cpp-dev
+script: make

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dRunner
+# dRunner [![Build Status](https://travis-ci.org/p-jackson/drunner.svg?branch=master)](https://travis-ci.org/p-jackson/drunner)
 
 ## Status
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dRunner [![Build Status](https://travis-ci.org/p-jackson/drunner.svg?branch=master)](https://travis-ci.org/p-jackson/drunner)
+# dRunner [![Build Status](https://travis-ci.org/drunner/drunner.svg?branch=master)](https://travis-ci.org/drunner/drunner)
 
 ## Status
 


### PR DESCRIPTION
From the commit history it sounds like there's a secret Jenkins server somewhere that runs the build. But dRunner's a public repo right, so why not have public CI?

The CI currently only checks whether the build is successful, doesn't run the unit tests.

1. I couldn't figure out how to run the tests
2. Looks like the tests always return `0` anyway, so Travis can't know when they've failed

But checking the compile is still useful, especially since it'll automatically check all pull requests.

You can see an example of it working (including a successful build badge at the top of the readme) in this repo: https://github.com/p-jackson/drunner